### PR TITLE
Fix errors when only rotate is enabled on text.

### DIFF
--- a/src/svg.select.js
+++ b/src/svg.select.js
@@ -130,7 +130,11 @@
         }
 
         if (this.options.rotationPoint) {
-            this.rectSelection.set.get(9).center(bbox.width / 2, 20);
+            if (this.rectSelection.set.members >= 9) {
+                this.rectSelection.set.get(9).center(bbox.width / 2, 20);
+            } else if (this.rectSelection.set.members === 2) {
+                this.rectSelection.set.get(2).center(bbox.width / 2, 20);
+            }
         }
     };
 


### PR DESCRIPTION
I was getting many errors when rotating or moving text element with having resize disabled.